### PR TITLE
Fixes a typo.

### DIFF
--- a/ios/Classes/ZegoExpressEnginePlugin.m
+++ b/ios/Classes/ZegoExpressEnginePlugin.m
@@ -948,7 +948,7 @@
       
     } else if ([@"enableBeautify" isEqualToString:call.method]) {
         
-        int feature = [ZegoUtils intValue:args[@"feature"]];
+        int feature = [ZegoUtils intValue:args[@"featureBitmask"]];
         int channel = [ZegoUtils intValue:args[@"channel"]];
         
         [[ZegoExpressEngine sharedEngine] enableBeautify:(ZegoBeautifyFeature)feature channel:(ZegoPublishChannel)channel];


### PR DESCRIPTION
It looks like "feature" has been renamed to "featureBitmask" but the change
is not applied to the iOS plugin. So, we should fix the typo otherwise we
cannot use the beautify effects on iOS.